### PR TITLE
Fix issues causing null relationships to not filter correctly.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Fixed issues causing filtering to not show entities with null relationships.
+
 ## [2.1.0] - 2019-12-09 
 ### Changed
 - Lessened restrictions on dependency versions.

--- a/src/Repositories/AbstractJsonApiDoctrineRepository.php
+++ b/src/Repositories/AbstractJsonApiDoctrineRepository.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace Giadc\DoctrineJsonApi\Repositories;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Tools\Pagination\Paginator;
-use Giadc\DoctrineJsonApi\Repositories\Processors;
 use Giadc\JsonApiRequest\Requests\Filters;
 use Giadc\JsonApiRequest\Requests\Includes;
-use Giadc\JsonApiRequest\Requests\Pagination;
 use Giadc\JsonApiRequest\Requests\RequestParams;
 use Giadc\JsonApiRequest\Requests\Sorting;
 
@@ -17,7 +16,7 @@ abstract class AbstractJsonApiDoctrineRepository
     protected $class;
 
     /**
-     * Get the default Sorting for the repository
+     * Get the default Sorting for the repository.
      *
      * @return array
      */
@@ -27,19 +26,19 @@ abstract class AbstractJsonApiDoctrineRepository
     }
 
     /**
-     * Paginate entities with Includes, Sorting, and Filters
+     * Paginate entities with Includes, Sorting, and Filters.
      *
-     * @param  RequestParams $params
-     * @param  array $additionalIncludes
      * @return Doctrine\ORM\Tools\Pagination\Paginator
      */
-    public function paginateAll(RequestParams $params, array $additionalIncludes = []): Paginator
-    {
+    public function paginateAll(
+        RequestParams $params,
+        array $additionalIncludes = []
+    ): Paginator {
         $qb = $this->em->createQueryBuilder();
         $includes = $params->getIncludes();
         $includes->add($additionalIncludes);
 
-        $qb->select('e') ->from($this->class, 'e');
+        $qb->select('e')->from($this->class, 'e');
 
         $qb = $this->processSorting($qb, $params->getSortDetails());
         $qb = $this->processIncludes($qb, $includes);
@@ -52,45 +51,50 @@ abstract class AbstractJsonApiDoctrineRepository
     }
 
     /**
-     * Find an entity by ID
+     * Find an entity by ID.
      *
-     * @param  string        $value
-     * @param  Includes|null $includes
      * @return mixed
      */
     public function findById(string $value, Includes $includes = null)
     {
         $results = $this->findByField($value, 'id', $includes);
+
         return $results == null ? null : $results[0];
     }
 
     /**
-     * Find entity by field value
+     * Find entity by field value.
      *
      * @param  mixed         $value
-     * @param  string        $field
-     * @param  Includes|null $includes
+     *
      * @return mixed
      */
-    public function findOneByField($value, string $field = 'id', Includes $includes = null)
-    {
+    public function findOneByField(
+        $value,
+        string $field = 'id',
+        Includes $includes = null
+    ) {
         $results = $this->findByField($value, $field, $includes);
+
         return $results == null ? null : $results[0];
     }
 
     /**
-     * Find entities by field value
+     * Find entities by field value.
      *
      * @param  mixed         $value
-     * @param  string        $field
-     * @param  Includes|null $includes
+     *
      * @return ArrayCollection
      */
-    public function findByField($value, string $field = 'id', Includes $includes = null)
-    {
+    public function findByField(
+        $value,
+        string $field = 'id',
+        Includes $includes = null
+    ) {
         $qb = $this->em->createQueryBuilder();
 
-        $qb->select('e')
+        $qb
+            ->select('e')
             ->from($this->class, 'e')
             ->where('e.' . $field . ' = ?1');
 
@@ -104,15 +108,15 @@ abstract class AbstractJsonApiDoctrineRepository
     }
 
     /**
-     * Find enties by an array of field values
+     * Find enties by an array of field values.
      *
-     * @param  array         $array
-     * @param  string        $field
-     * @param  Includes|null $includes
      * @return ArrayCollection
      */
-    public function findByArray(array $array, string $field = 'id', Includes $includes = null)
-    {
+    public function findByArray(
+        array $array,
+        string $field = 'id',
+        Includes $includes = null
+    ) {
         $qb = $this->em->createQueryBuilder();
         $qb->select('e');
         $qb->from($this->class, 'e');
@@ -126,9 +130,10 @@ abstract class AbstractJsonApiDoctrineRepository
     }
 
     /**
-     * Updates or creates an Entity
+     * Updates or creates an Entity.
      *
      * @param $entity
+     *
      * @return mixed
      */
     public function createOrUpdate($entity)
@@ -145,9 +150,10 @@ abstract class AbstractJsonApiDoctrineRepository
     }
 
     /**
-     * Update an existing Entity
+     * Update an existing Entity.
      *
      * @param $entity
+     *
      * @return void
      */
     public function update($entity, bool $mute = false)
@@ -161,10 +167,9 @@ abstract class AbstractJsonApiDoctrineRepository
     }
 
     /**
-     * Add a new Entity to the database
+     * Add a new Entity to the database.
      *
      * @param mixed   $entity
-     * @param boolean $mute
      */
     public function add($entity, bool $mute = false)
     {
@@ -177,10 +182,9 @@ abstract class AbstractJsonApiDoctrineRepository
     }
 
     /**
-     * Delete an Entity from the database
+     * Delete an Entity from the database.
      *
      * @param  mixed   $entity
-     * @param  boolean $mute
      */
     public function delete($entity, bool $mute = false)
     {
@@ -193,7 +197,7 @@ abstract class AbstractJsonApiDoctrineRepository
     }
 
     /**
-     * Flush pending changes to the database
+     * Flush pending changes to the database.
      */
     public function flush()
     {
@@ -210,10 +214,11 @@ abstract class AbstractJsonApiDoctrineRepository
     }
 
     /**
-     * Is the given Entity a valid member of this Repository
+     * Is the given Entity a valid member of this Repository.
      *
      * @param  mixed $entity
-     * @return boolean
+     *
+     * @return bool
      */
     protected function isValidEntity($entity)
     {

--- a/tests/ExampleClasses/ExampleFilters.php
+++ b/tests/ExampleClasses/ExampleFilters.php
@@ -13,5 +13,14 @@ class ExampleFilters extends FilterManager
         'name'  => ['type' => 'keyword'],
         'size'  => ['type' => 'combined', 'keys' => ['width', 'height'], 'separator' => 'x'],
         'dates' => ['type' => 'date', 'key' => 'runDate'],
+        'combined' => [
+            'type' => 'combined',
+            'keys' => [
+                'name',
+                'relationships.firstName',
+                'relationships.lastName',
+            ],
+            'separator' => ' ',
+        ],
     ];
 }

--- a/tests/ExampleClasses/ExampleRelationshipEntity.php
+++ b/tests/ExampleClasses/ExampleRelationshipEntity.php
@@ -10,6 +10,12 @@ class ExampleRelationshipEntity
     /** @var ExampleEntity */
     private $parent;
 
+    /** @var string */
+    private $firstName= 'fake';
+
+    /** @var string */
+    private $lastName = 'name';
+
     public function __construct($id)
     {
         $this->id = $id;

--- a/tests/Filters/FilterManagerTest.php
+++ b/tests/Filters/FilterManagerTest.php
@@ -2,6 +2,8 @@
 
 use Giadc\JsonApiRequest\Requests\Filters;
 use Giadc\DoctrineJsonApi\Tests\ExampleFilters;
+use Giadc\DoctrineJsonApi\Tests\ExampleEntity;
+use Giadc\DoctrineJsonApi\Tests\ExampleRelationshipEntity;
 use PHPUnit\Framework\TestCase;
 
 class FilterManagerTest extends TestCase
@@ -21,7 +23,7 @@ class FilterManagerTest extends TestCase
         $entityManager = EntityManagerFactory::createEntityManager();
         $qb            = $entityManager->createQueryBuilder();
 
-        $qb->select('e')->from('App\Entities\Entity', 'e');
+        $qb->select('e')->from(ExampleEntity::class, 'e');
 
         $filters = new Filters([
             'id'    => '123',
@@ -32,7 +34,12 @@ class FilterManagerTest extends TestCase
 
         $result = $this->filterManager->process($qb, $filters)->getQuery();
 
-        $expectedDQL = "SELECT e FROM App\Entities\Entity e WHERE e.id = ?1 AND e.name LIKE ?2 AND CONCAT(e.width, 'x', e.height) LIKE ?3 AND (e.runDate BETWEEN ?4 AND ?5)";
+        $expectedDQL = "SELECT e FROM " . ExampleEntity::class . " e " .
+            "WHERE e.id = ?1 " .
+                "AND e.name LIKE ?2 " .
+                "AND CONCAT(e.width, 'x', e.height) LIKE ?3 " .
+                "AND (e.runDate BETWEEN ?4 AND ?5)";
+
         $this->assertEquals($expectedDQL, $result->getDql());
 
         $paramArray = $result->getParameters()->map(function ($parameter) {
@@ -43,13 +50,48 @@ class FilterManagerTest extends TestCase
                 : $value;
         })->toArray();
 
-        $expectedParmArray = [
+        $expectedParamArray = [
             '123',
             '%Eduardo%',
             '%10x10%',
             '2016-01-01 00:00:00',
             '2020-02-02 23:59:59',
         ];
-        $this->assertEquals($expectedParmArray, $paramArray);
+        $this->assertEquals($expectedParamArray, $paramArray);
+    }
+
+    public function test_it_separates_join_concats(): void
+    {
+        $entityManager = EntityManagerFactory::createEntityManager();
+        $qb            = $entityManager->createQueryBuilder();
+
+        $qb->select('e')->from(ExampleEntity::class, 'e');
+
+        $filters = new Filters([
+            // 'id' => 'asdf',
+            'combined' => 'summer asdf'
+        ]);
+
+        $result = $this->filterManager->process($qb, $filters)->getQuery();
+
+        $expectedDQL = "SELECT e FROM " . ExampleEntity::class . " e ".
+            "LEFT JOIN e.relationships relationships ".
+            "WHERE e.name LIKE ?1 ".
+                "OR CONCAT(relationships.firstName, ' ', relationships.lastName) LIKE ?1";
+
+        $this->assertEquals($expectedDQL, $result->getDql());
+
+        $paramArray = $result->getParameters()->map(function ($parameter) {
+            $value = $parameter->getValue();
+
+            return ($value instanceof \DateTime)
+                ? $value->format('Y-m-d H:i:s')
+                : $value;
+        })->toArray();
+
+        $expectedParamArray = [
+            "%summer asdf%"
+        ];
+        $this->assertEquals($expectedParamArray, $paramArray);
     }
 }


### PR DESCRIPTION
This needs a major refactor...so I did not want to spend any time doing clean-up and only focus on the filter issues.

ISSUE: When using `CONCAT` for `combined` filters with relationships that could be null...only returns entities that are not null. 

I extracted all relationships into their own statement.

Note: Example isn't perfect this since was a bigger issue with ManyToMany relationships. 

```
SELECT e FROM fake_entity e
        LEFT JOIN e.relationships relationships
    WHERE CONCAT(e.name, ' ', relationships.firstName, ' ', relationships.lastName) LIKE ?1
```
Becomes: 
```
SELECT e FROM fake_entity e
        LEFT JOIN e.relationships relationships
    WHERE e.name LIKE ?1
        OR CONCAT(relationships.firstName, ' ', relationships.lastName) LIKE ?1
```