### PR TITLE
GCCDEV-4153: Empty filters do not create empty WHERE clauses.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+-   Empty filter values do not result in empty WHERE clauses ([GCCDEV-4153](https://jira.gannett.com/browse/GCCDEV-4153)).
+
 ## [4.0.0] - 2022-09-12
 
 ### Changed

--- a/src/Filters/FilterManager.php
+++ b/src/Filters/FilterManager.php
@@ -79,7 +79,7 @@ abstract class FilterManager
     /**
      * @throws \Exception
      */
-    private function processFilter(string $key, mixed $data): void
+    private function processFilter(string $key, array $data): void
     {
         $info   = $this->accepted[$key];
         $key    = $this->getValidKey($info, $key);
@@ -104,7 +104,7 @@ abstract class FilterManager
     /**
      * @phpstan-param string|string[] $key
      */
-    private function idBuilder(mixed $data, string|array $key): void
+    private function idBuilder(array $data, string|array $key): void
     {
         if (is_array($key)) {
             $this->buildMultiple($data, $key);
@@ -126,7 +126,7 @@ abstract class FilterManager
     /**
      * @phpstan-param string[] $keys
      */
-    private function buildMultiple(mixed $data, array $keys): void
+    private function buildMultiple(array $data, array $keys): void
     {
         $conditions = [];
 
@@ -142,7 +142,7 @@ abstract class FilterManager
         $this->setParameter($this->paramInt, $data);
     }
 
-    private function buildSingle(mixed $data, string $key): void
+    private function buildSingle(array $data, string $key): void
     {
         if (is_array($data) && count($data) > 1) {
             $this->qb->andWhere($this->qb->expr()->in($this->getKey($key), '?' . $this->paramInt));
@@ -160,7 +160,7 @@ abstract class FilterManager
     /**
      * @phpstan-param string|string[] $keys
      */
-    private function keywordBuilder(mixed $data, string|array $keys): void
+    private function keywordBuilder(array $data, string|array $keys): void
     {
         if (is_array($keys)) {
             $conditions = $this->buildMultipleConditions($data, $keys);
@@ -178,7 +178,7 @@ abstract class FilterManager
      * @phpstan-param string[] $keys
      * @phpstan-return array<\Doctrine\ORM\Query\Expr\Comparison>
      */
-    private function buildMultipleConditions(mixed $data, array $keys): array
+    private function buildMultipleConditions(array $data, array $keys): array
     {
         $conditions = [];
 
@@ -192,7 +192,7 @@ abstract class FilterManager
     /**
      * @phpstan-return array<\Doctrine\ORM\Query\Expr\Comparison>
      */
-    private function buildSingleConditions(mixed $data, string $key): array
+    private function buildSingleConditions(array $data, string $key): array
     {
         $conditions = [];
 
@@ -209,7 +209,7 @@ abstract class FilterManager
         return $conditions;
     }
 
-    protected function nullBuilder(mixed $data, string $key): void
+    protected function nullBuilder(array $data, string $key): void
     {
         if (is_array($data)) {
             $data = $data[0];
@@ -236,7 +236,7 @@ abstract class FilterManager
     /**
      * Build a `combined` filter
      */
-    private function combinedBuilder(mixed $data, string $key): void
+    private function combinedBuilder(array $data, string $key): void
     {
         /** @phpstan-var CombinedFilter */
         $info      = $this->accepted[$key];
@@ -255,7 +255,7 @@ abstract class FilterManager
      * @phpstan-param string[] $keys
      * @phpstan-return array<\Doctrine\ORM\Query\Expr\Comparison>
      */
-    private function buildCombinedConditions(mixed $data, array $keys, string $separator): array
+    private function buildCombinedConditions(array $data, array $keys, string $separator): array
     {
         $conditions = [];
         $concatArrays = $this->getConcatArrays($keys, $separator);
@@ -305,7 +305,7 @@ abstract class FilterManager
      * @phpstan-param string|string[] $keys
      * @throws \Exception
      */
-    private function dateBuilder(mixed $data, string|array $keys): QueryBuilder
+    private function dateBuilder(array $data, string|array $keys): QueryBuilder
     {
         if (!is_array($keys)) {
             return $this->qb->andWhere($this->buildSingleDate($data, $keys));
@@ -324,7 +324,7 @@ abstract class FilterManager
         return $this->qb->andWhere($sql);
     }
 
-    private function buildSingleDate(mixed $data, string $key): string
+    private function buildSingleDate(array $data, string $key): string
     {
         if (is_array($data)) {
             $data = $data[0];

--- a/src/Filters/FilterManager.php
+++ b/src/Filters/FilterManager.php
@@ -53,7 +53,10 @@ abstract class FilterManager
         $this->qb = $qb;
 
         foreach ($filters->toArray() as $key => $data) {
-            if (array_key_exists($key, $this->accepted)) {
+            if (
+                count($data) > 0
+                && array_key_exists($key, $this->accepted)
+            ) {
                 $this->processFilter($key, $data);
             }
         }

--- a/tests/Filters/FilterManagerTest.php
+++ b/tests/Filters/FilterManagerTest.php
@@ -99,4 +99,26 @@ class FilterManagerTest extends TestCase
         ];
         $this->assertEquals($expectedParamArray, $paramArray);
     }
+
+    public function test_it_ignores_empty_filter_values(): void {
+        $entityManager = EntityManagerFactory::createEntityManager();
+        $qb            = $entityManager->createQueryBuilder();
+
+        $qb->select('e')->from(ExampleEntity::class, 'e');
+
+        $filters = new Filters([
+            'id' => '',
+            'name' => '',
+            'deleted' => '',
+            'size' => '',
+            'dates' => '',
+        ]);
+
+        $result = $this->filterManager?->process($qb, $filters)->getQuery();
+        $this->assertNotNull($result, 'FilterManager could not be found');
+
+        // No WHERE clauses
+        $expectedDQL = sprintf("SELECT e FROM %s e", ExampleEntity::class);
+        $this->assertEquals($expectedDQL, $result->getDql());
+    }
 }


### PR DESCRIPTION
## Jira

https://jira.gannett.com/browse/GCCDEV-4153

## Description

1. Doesn't process filters if their value is empty (ie. from `?filter[name]=&filter[name2]=`.
2. Updates the `$data` attributes from `mixed` to `array`, since `json-api-request` always converts these to an array of strings.

## Gif

![dc](https://media.giphy.com/media/fea8noV27iiwUcb0VK/giphy.gif)